### PR TITLE
fix(shared/ipc): verbose logging should use `console.debug`

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -41,7 +41,7 @@ export function addInterruptIpc(func: InterruptIPC, options?: InterruptIPCOption
 if (verboseLogging) {
     addInterruptIpc(
         (args) =>
-            console.log(
+            console.debug(
                 `[IPC] (In)`,
                 global.window
                     ? JSON.stringify(args)
@@ -56,7 +56,7 @@ if (verboseLogging) {
     );
     addInterruptIpc(
         (args) =>
-            console.log(
+            console.debug(
                 `[IPC] (Out)`,
                 global.window
                     ? JSON.stringify(args)


### PR DESCRIPTION
使用 `console.debug` 而不是 `console.log` 显示 IPC 调试信息